### PR TITLE
Escape literal curly braces if we're going to be using "format".

### DIFF
--- a/agnostic/cli.py
+++ b/agnostic/cli.py
@@ -592,7 +592,7 @@ def _migration_insert_sql(config, outfile):
     with _get_db_cursor(config) as (db, cursor):
         insert_sql = (
             "INSERT INTO {schema}agnostic_migrations VALUES "
-            "('{}', '{}', NOW(), NOW());\n".format(schema=schema)
+            "('{{}}', '{{}}', NOW(), NOW());\n".format(schema=schema)
         )
 
         for migration in config.backend.get_migration_records(cursor):


### PR DESCRIPTION
You might see this error when trying to run your fork of Agnostic:

```
    Migrations completed successfully.
    Creating snapshot of database "catalog_metadata"…
    Error: Not able to create snapshot: tuple index out of range
```

This PR fixes that error.