### PR TITLE
Adding a CLI option to use a snowflake private key if provided

### DIFF
--- a/agnostic/__init__.py
+++ b/agnostic/__init__.py
@@ -72,7 +72,7 @@ class Migration():
         )
 
 
-def create_backend(db_type, host, port, user, password, database, schema):
+def create_backend(db_type, host, port, user, password, database, schema, private_key=None):
     '''
     Return a new backend instance.
     '''
@@ -80,6 +80,9 @@ def create_backend(db_type, host, port, user, password, database, schema):
     if db_type == 'mysql':
         if schema is not None:
             raise RuntimeError('MySQL does not support schemas.')
+        if private_key is not None:
+            raise RuntimeError('MySQL does not support private keys.')
+
 
         try:
             from agnostic.mysql import MysqlBackend
@@ -92,6 +95,9 @@ def create_backend(db_type, host, port, user, password, database, schema):
         return MysqlBackend(host, port, user, password, database, schema)
 
     elif db_type == 'postgres':
+        if private_key is not None:
+            raise RuntimeError('Postgres does not support private keys.')
+
         try:
             from agnostic.postgres import PostgresBackend
         except ImportError as ie:
@@ -111,7 +117,7 @@ def create_backend(db_type, host, port, user, password, database, schema):
                 raise RuntimeError(msg)
             else:
                 raise
-        return SnowflakeBackend(host, port, user, password, database, schema)
+        return SnowflakeBackend(host, port, user, password, database, schema, private_key)
 
     else:
         raise ValueError('Invalid database type: "{}"'.format(db_type))
@@ -131,7 +137,7 @@ class AbstractBackend(metaclass=ABCMeta):
 
         return location
 
-    def __init__(self, host, port, user, password, database, schema):
+    def __init__(self, host, port, user, password, database, schema, private_key=None):
         ''' Constructor. '''
 
         self._host = host
@@ -140,6 +146,7 @@ class AbstractBackend(metaclass=ABCMeta):
         self._password = password
         self._database = database
         self._schema = schema
+        self._private_key = private_key
 
     @abstractmethod
     def backup_db(self, backup_file):

--- a/agnostic/cli.py
+++ b/agnostic/cli.py
@@ -90,6 +90,14 @@ pass_config = click.make_pass_decorator(Config, ensure=True)
     help='Path to migrations directory. (default: ./migrations)'
 )
 @click.option(
+    '-k', '--private-key',
+    envvar='SNOWFLAKE_PRIVATE_KEY',
+    metavar='<private_key>',
+    required=False,
+    hide_input=True,
+    help='Snowflake private_key, as an alternative way of authentication. Either password or this key must be provided'
+)
+@click.option(
     '-D', '--debug',
     is_flag=True,
     help='Display stack traces when exceptions occur.'
@@ -97,7 +105,7 @@ pass_config = click.make_pass_decorator(Config, ensure=True)
 @click.version_option()
 @pass_config
 def main(config, db_type, host, port, user, password, database, schema,
-         migrations_dir, debug):
+         migrations_dir, private_key, debug):
     ''' Agnostic database migrations: upgrade schemas, save your sanity. '''
 
     config.debug = debug
@@ -105,7 +113,7 @@ def main(config, db_type, host, port, user, password, database, schema,
 
     try:
         config.backend = create_backend(db_type, host, port, user, password,
-                                        database, schema)
+                                        database, schema, private_key)
     except RuntimeError as re:
         raise click.ClickException(str(re))
 

--- a/agnostic/snowflake.py
+++ b/agnostic/snowflake.py
@@ -1,3 +1,4 @@
+import base64
 import subprocess
 
 import snowflake.connector
@@ -15,13 +16,17 @@ class SnowflakeBackend(AbstractBackend):
 
         connect_args = {
             'user': self._user,
-            'password': self._password,
             'account': self._host,
             'database': self._database,
             'autocommit': True,
             'schema': self._schema
         }
 
+        if self._private_key is not None:
+            connect_args['private_key'] = base64.b64decode(self._private_key)
+            print('Snowflake private key found, using it for authentication.')
+        else:
+            connect_args['password'] = self._password
         if self._port is not None:
             connect_args['port'] = self._port
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/83974503/129423724-afaaf75f-6090-49ad-a4df-21c83eb0b7a7.png)
Giving the option to have snowflake use a private key so that we can do CLI migrations to save everyone a little bit of time.


Tested the other options to make sure they fail:

![image](https://user-images.githubusercontent.com/83974503/129423792-b037ea67-1115-465b-a058-bb6c2fa0cb81.png)
