### PR TITLE
[CAT-30863] add --if-exists flag when snapshot_db

### DIFF
--- a/agnostic/postgres.py
+++ b/agnostic/postgres.py
@@ -167,6 +167,7 @@ class PostgresBackend(AbstractBackend):
             '-O', # don't dump ownership commands
             '--clean',
             '--no-tablespaces',
+            '--if-exists',
         ]
 
         if self._port is not None:


### PR DESCRIPTION
https://instacart.atlassian.net/browse/CAT-30863

When loading schema for catalog_metadata db, it gives errors during the initial clean up phase if the DB does not exist. 

https://github.com/instacart/carrot/blob/master/catalog/infinity/db/catalog_metadata/schema.sql#L19-L31

There is no issue with these errors if we manually dump the schema. But when we are adding this DB into Bento profile, the set up would fail.