### PR TITLE
[CAT-30895] Postgres migration fails when using the latest agnostic commit sha

### DIFF
--- a/agnostic/__init__.py
+++ b/agnostic/__init__.py
@@ -78,12 +78,6 @@ def create_backend(db_type, host, port, user, password, database, schema, privat
     '''
 
     if db_type == 'mysql':
-        if schema is not None:
-            raise RuntimeError('MySQL does not support schemas.')
-        if private_key is not None:
-            raise RuntimeError('MySQL does not support private keys.')
-
-
         try:
             from agnostic.mysql import MysqlBackend
         except ImportError as ie:
@@ -95,9 +89,6 @@ def create_backend(db_type, host, port, user, password, database, schema, privat
         return MysqlBackend(host, port, user, password, database, schema)
 
     elif db_type == 'postgres':
-        if private_key is not None:
-            raise RuntimeError('Postgres does not support private keys.')
-
         try:
             from agnostic.postgres import PostgresBackend
         except ImportError as ie:


### PR DESCRIPTION
https://instacart.atlassian.net/browse/CAT-30895

Once I configure the latest agnostic change for testing, when running ./bin/migrate -d metadata, it gives Postgres does not support private keys. error

The reason for removing this raise exception is schema and private_key are loaded from env var when using the cli. So they can never be None.

https://github.com/AlexCharlton/agnostic/blob/master/agnostic/cli.py#L92-L98