### PR TITLE
Add a way for agnostic to fix itself so we don't have to do it manually

### DIFF
--- a/agnostic/cli.py
+++ b/agnostic/cli.py
@@ -403,6 +403,23 @@ def restore(config, schemafile):
 
 
 @click.command()
+@pass_config
+def fix(config, migration_name):
+    '''
+    Delete a failed migration from the agnostic db.
+    '''
+
+    click.echo('Deleting {} from catalog.agnostic_migrations'.format(migration_name))
+
+    try:
+        _wait_for(config.backend.fix_db(migration_name))
+    except Exception as e:
+        raise click.ClickException('Not able to delete failed migration: {}'.format(e))
+
+    click.secho('Migration deleted "{}".'.format(migration_name), fg='green')
+
+
+@click.command()
 @click.option(
     '-y', '--yes',
     is_flag=True,
@@ -512,6 +529,7 @@ main.add_command(restore)
 main.add_command(list_)
 main.add_command(test)
 main.add_command(migrate)
+main.add_command(fix)
 
 
 @contextmanager

--- a/agnostic/cli.py
+++ b/agnostic/cli.py
@@ -403,6 +403,7 @@ def restore(config, schemafile):
 
 
 @click.command()
+@click.argument('migration_name')
 @pass_config
 def fix(config, migration_name):
     '''

--- a/agnostic/mysql.py
+++ b/agnostic/mysql.py
@@ -137,3 +137,6 @@ class MysqlBackend(AbstractBackend):
         )
 
         return process
+
+    def fix_db(self, migration_name):
+        raise("Not implemented for mysql")

--- a/agnostic/mysql.py
+++ b/agnostic/mysql.py
@@ -138,5 +138,3 @@ class MysqlBackend(AbstractBackend):
 
         return process
 
-    def fix_db(self, migration_name):
-        raise("Not implemented for mysql")

--- a/agnostic/postgres.py
+++ b/agnostic/postgres.py
@@ -213,4 +213,4 @@ class PostgresBackend(AbstractBackend):
                     schemas.append(schema)
 
         return schemas
-    
+

--- a/agnostic/postgres.py
+++ b/agnostic/postgres.py
@@ -213,6 +213,4 @@ class PostgresBackend(AbstractBackend):
                     schemas.append(schema)
 
         return schemas
-
-    def fix_db(self, migration_name):
-        raise("Not implemented for psql")
+    

--- a/agnostic/postgres.py
+++ b/agnostic/postgres.py
@@ -213,3 +213,6 @@ class PostgresBackend(AbstractBackend):
                     schemas.append(schema)
 
         return schemas
+
+    def fix_db(self, migration_name):
+        raise("Not implemented for psql")

--- a/agnostic/snowflake.py
+++ b/agnostic/snowflake.py
@@ -51,3 +51,6 @@ class SnowflakeBackend(AbstractBackend):
 
     def snapshot_db(self, snapshot_file):
         raise('Snowflake cannot snapshot DB')
+
+    def fix_db(self, migration_name):
+        return

--- a/agnostic/snowflake.py
+++ b/agnostic/snowflake.py
@@ -51,6 +51,3 @@ class SnowflakeBackend(AbstractBackend):
 
     def snapshot_db(self, snapshot_file):
         raise('Snowflake cannot snapshot DB')
-
-    def fix_db(self, migration_name):
-        return


### PR DESCRIPTION
### Context Links
Sox will break our agnostic migration restore process, this is to prevent that.

### Description
Adds support for a new way to run our migration script
"./migrate_<dev/prod>.sh --fix <migration_name>"

If the migration failed, it will be deleted and unblock future migrations.